### PR TITLE
A few low-level gas optimizations.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsequence/sstore2",
-  "version": "1.1.0",
+  "version": "1.2.1",
   "files": [
     "/contracts/**/*.sol",
     "/artifacts/contracts/*.json",


### PR DESCRIPTION
Changes to `contracts/utils/Bytecode.sol`:

- `creationCodeFor` has been changed to use `PUSH2` instead of `PUSH4` since there is a max contract size limit of `24576 bytes` which is less than `2^16 = 65536 (uint16)`. Also `PUSH1 0` instructions have been changed to `RETURNDATASIZE`.
- `codeAt` has been changed so that only one subtraction is used to calculate `size` and also an extra addition in the `assembly` block has been removed to replace `0x20 + 0x1f` with `0x3f`.

All tests are passing.